### PR TITLE
feat(pinescript): expose hidden +1/0/-1 backtest posture plot (AIE-850)

### DIFF
--- a/ports/pinescript/lorentzian-classification-v2.pine
+++ b/ports/pinescript/lorentzian-classification-v2.pine
@@ -638,6 +638,16 @@ backTestStream = switch
     endShortTrade => -2
 plot(backTestStream, "Backtest Stream", display=display.none)
 
+// The following carries those streamed events forward as a +1/0/-1 position posture for backtest adapters
+var int backTestSignal = 0
+if startLongTrade
+    backTestSignal := 1
+else if startShortTrade
+    backTestSignal := -1
+else if (endLongTrade and backTestSignal == 1) or (endShortTrade and backTestSignal == -1)
+    backTestSignal := 0
+plot(backTestSignal, "Backtest Signal", display=display.none)
+
 // The following can be used to display real-time trade stats. This can be a useful mechanism for obtaining real-time feedback during Feature Engineering. This does NOT replace the need to properly backtest.
 // Note: In this context, a "Stop-Loss" is defined instances where the ML Signal prematurely flips directions before an exit signal can be generated.
 [totalWins, totalLosses, totalEarlySignalFlips, totalTrades, tradeStatsHeader, winLossRatio, winRate] = ml.backtest(high, low, open, startLongTrade, endLongTrade, startShortTrade, endShortTrade, isEarlySignalFlip, maxBarsBackIndex, bar_index, settings.source, useWorstCase)

--- a/tests/parity/fixtures_manifest.json
+++ b/tests/parity/fixtures_manifest.json
@@ -6,8 +6,8 @@
       "name": "lcv6",
       "path": "PineScript/Indicators/lcv6.pine",
       "role": "canonical PineScript source for Python parity",
-      "sha256": "4cffc404ef8867744aece70e9f22184c527e6e34f7a7a3c7a224521253152542",
-      "code_sha256": "edd9f0c6af0c2f891074fdc82070a0be848f73ae952199f1241373ecb5fe18f9",
+      "sha256": "d36518f550ee655dc4f018dbcc737a45040cfe1639c22265429eaa922e026a0c",
+      "code_sha256": "e9cc5a9ccfb5ac24590445b2a43a640576afda94a28f2c578146efe1b39fd9e1",
       "allow_debug_markers": false
     },
     {


### PR DESCRIPTION
## Summary
Adds a hidden `Backtest Signal` plot to the canonical Pine source: a `var`-carried +1/0/-1 posture folded from the existing `startLongTrade`/`endLongTrade`/`startShortTrade`/`endShortTrade` events. The AI Edge Studio optimizer executes a designated series as exactly +1/0/-1 per bar (verified against the pinned A2 runtime — optimizer PR #246), so the event-coded `backTestStream` (na off-event, ±2 exits) cannot be designated; this plot can. Additive only: no existing line changes, `backTestStream` is untouched, and TradingView users see no visual change (`display=display.none`).

Semantics: entries take precedence over exits (matching the existing `switch` case order, so a flip bar resolves to the new side's posture); an exit zeroes the posture only when its side is actually held, so a stale opposite-side exit event is harmless.

Linear: [AIE-850](https://linear.app/ai-edge/issue/AIE-850)

## Validation
- `PYTHONPATH=ports/python python3 -m unittest discover -s tests` → 150 tests OK (6 pre-existing skips for the external TradingView export dir).
- `tests/parity/fixtures_manifest.json` pins re-locked intentionally for the new bytes (`sha256` + `code_sha256`); the pin test passes.
- Repo helpers verified on the new file: `has_debug_markers` False; plot records gain only `Backtest Signal`; `plotshape`/`alertcondition` sets unchanged (those are pinned exhaustively — this is why the posture is a `plot`).

## Release Notes
- PineScript: new hidden `Backtest Signal` plot (+1 long / 0 flat / -1 short) for backtest adapters; visible in the Data Window and CSV exports, invisible on the chart.

## Checklist
- [x] Tests pass locally
- [x] Parity notes updated if algorithm behavior changed — signal behavior is unchanged; only the manifest pins moved, intentionally
- [x] Ports kept in parity — the posture is Pine-display-only by design: it derives entirely from columns every port already exports, and the 40-column export schema is deliberately not widened (see MQL5 PORTING_NOTES precedent)